### PR TITLE
Add support for ACT ESA

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ This custom component automatically generates the following entities:
 Install this component via HACS, then go to "Configuration" -> "Integrations" and search for "NSW Rural Fire Service - Fire Danger".
 You have to select your district from the list, choose a feed, and then hit "Submit".
 
-There are currently two different feeds supported:
+There are currently three different feeds supported:
 * Standard: This provides a forecast for today and tomorrow only, and appears as a dedicated feed on the RFS's website.
 * Extended: This provides a forecast for 4 days, and is [used on the RFS's website](https://www.rfs.nsw.gov.au/fire-information/fdr-and-tobans). 
+* ACT Standard: While the Australian Capital Territory is included in the NSW RFS feed, it has in the past failed to include total fire bans declared by the 
+ACT Emergency Services Agency (ESA). As such this provides a forecast for today and tomorrow only using the ACT ESAs data feed.
 
-There is currently no option to switch between the two feeds, so please delete and recreate the configuration if you want to switch feeds.
+There is currently no option to switch between the three feeds, so please delete and recreate the configuration if you want to switch feeds.
 
 The actual feed contains the value "NONE" in case no rating has been issued. This is converted into `None` which has a special meaning in Python and hence in Home Assistant, 
 and which subsequently may cause confusion when used in automations. There is an option available when setting up this integration to automatically convert this into "No Rating" 

--- a/custom_components/nsw_rural_fire_service_fire_danger/__init__.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_SCAN_INTERVAL, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -60,7 +60,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     data_feed = conf.get(CONF_DATA_FEED, DEFAULT_DATA_FEED)
     convert_no_rating = conf.get(CONF_CONVERT_NO_RATING, DEFAULT_CONVERT_NO_RATING)
     scan_interval = conf.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    identifier = f"{district_name}"
+    identifier = conf[CONF_UNIQUE_ID]
+
     if identifier in configured_instances(hass):
         return True
 

--- a/custom_components/nsw_rural_fire_service_fire_danger/__init__.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     VALID_DATA_FEEDS,
 )
 from .coordinator import (
+    ActEsaFireDangerStandardFeedCoordinator,
     NswRfsFireDangerExtendedFeedCoordinator,
     NswRfsFireDangerFeedCoordinator,
     NswRfsFireDangerStandardFeedCoordinator,
@@ -88,6 +89,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data_feed_coordinator = NswRfsFireDangerStandardFeedCoordinator(hass, entry)
     elif data_feed == "extended":
         data_feed_coordinator = NswRfsFireDangerExtendedFeedCoordinator(hass, entry)
+    elif data_feed == "act_standard":
+        data_feed_coordinator = ActEsaFireDangerStandardFeedCoordinator(hass, entry)
     else:
         raise NotImplementedError(f"Unsupported data feed type {data_feed} selected.")
     hass.data[DOMAIN][entry.entry_id] = data_feed_coordinator

--- a/custom_components/nsw_rural_fire_service_fire_danger/__init__.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     data_feed = conf.get(CONF_DATA_FEED, DEFAULT_DATA_FEED)
     convert_no_rating = conf.get(CONF_CONVERT_NO_RATING, DEFAULT_CONVERT_NO_RATING)
     scan_interval = conf.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-    identifier = conf[CONF_UNIQUE_ID]
+    identifier = conf.get(CONF_UNIQUE_ID, district_name)
 
     if identifier in configured_instances(hass):
         return True

--- a/custom_components/nsw_rural_fire_service_fire_danger/config_flow.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/config_flow.py
@@ -66,7 +66,8 @@ class NswRuralFireServiceFireDangerFlowHandler(
         """Handle the start of the config flow."""
         if not user_input:
             return await self._show_form()
-        if user_input[CONF_DATA_FEED] in ACT_DATA_FEEDS:
+        data_feed = user_input.get(CONF_DATA_FEED, None)
+        if data_feed in ACT_DATA_FEEDS:
             identifier = f"{user_input[CONF_DISTRICT_NAME]} {ACT_IDENTIFIER_SUFFIX}"
         else:
             identifier = f"{user_input[CONF_DISTRICT_NAME]}"

--- a/custom_components/nsw_rural_fire_service_fire_danger/const.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/const.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Final
 
 from homeassistant.const import Platform
+from homeassistant.util import dt as dt_util
 
 CONF_CONVERT_NO_RATING: Final = "convert_no_rating"
 CONF_DISTRICT_NAME: Final = "district_name"
@@ -53,11 +54,11 @@ XML_EXTRA_ATTRIBUTES: Final = {
     # <XML Key>: [<Display Name>, <Conversion Function>]
     "lastBuildDate": [
         "last_build_date",
-        lambda x, y: datetime.strptime(x, "%a, %d %b %Y %H:%M:%S %z"),
+        lambda x, y: dt_util.as_utc(datetime.strptime(x, "%a, %d %b %Y %H:%M:%S %z")),
     ],
     "pubDate": [
         "publish_date",
-        lambda x, y: datetime.strptime(x, "%a, %d %b %Y %H:%M:%S %z"),
+        lambda x, y: dt_util.as_utc(datetime.strptime(x, "%a, %d %b %Y %H:%M:%S %z")),
     ],
 }
 

--- a/custom_components/nsw_rural_fire_service_fire_danger/const.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/const.py
@@ -1,5 +1,5 @@
 """NSW Rural Fire Service - Fire Danger - Consts."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Final
 
 from homeassistant.const import Platform
@@ -9,6 +9,7 @@ CONF_DISTRICT_NAME: Final = "district_name"
 CONF_DATA_FEED: Final = "data_feed"
 
 DEFAULT_ATTRIBUTION: Final = "NSW Rural Fire Service"
+DEFAULT_ACT_ATTRIBUTION = "ACT Emergency Services Agency"
 
 DEFAULT_DATA_FEED: Final = "standard"
 
@@ -25,6 +26,10 @@ DOMAIN: Final = "nsw_rural_fire_service_fire_danger"
 XML_DISTRICT: Final = "District"
 XML_FIRE_DANGER_MAP: Final = "FireDangerMap"
 XML_NAME: Final = "Name"
+XML_RSS: Final = "rss"
+XML_CHANNEL: Final = "channel"
+XML_LAST_BUILD_DATE: Final = "lastBuildDate"
+XML_PUB_DATE: Final = "pubDate"
 XML_SENSOR_ATTRIBUTES: Final = {
     # <XML Key>: [<Display Name>, <Conversion Function>]
     "RegionNumber": ["region_number", lambda x, y: int(x)],
@@ -39,6 +44,17 @@ XML_SENSOR_ATTRIBUTES: Final = {
     ],
     "FireBanToday": ["fire_ban_today", lambda x, y: x == "Yes"],
     "FireBanTomorrow": ["fire_ban_tomorrow", lambda x, y: x == "Yes"],
+}
+XML_EXTRA_ATTRIBUTES: Final = {
+    # <XML Key>: [<Display Name>, <Conversion Function>]
+    "lastBuildDate": [
+        "last_build_date",
+        lambda x, y: datetime.strptime(x, "%a, %d %b %Y %H:%M:%S %z"),
+    ],
+    "pubDate": [
+        "publish_date",
+        lambda x, y: datetime.strptime(x, "%a, %d %b %Y %H:%M:%S %z"),
+    ],
 }
 
 JSON_AREA_NAME = "areaName"
@@ -77,6 +93,7 @@ BINARY_SENSOR_TYPES_EXTENDED: Final = BINARY_SENSOR_TYPES_STANDARD + [
 BINARY_SENSOR_TYPES: Final = {
     "standard": BINARY_SENSOR_TYPES_STANDARD,
     "extended": BINARY_SENSOR_TYPES_EXTENDED,
+    "act_standard": BINARY_SENSOR_TYPES_STANDARD,
 }
 
 SENSOR_TYPES_STANDARD: Final = ["danger_level_today", "danger_level_tomorrow"]
@@ -87,6 +104,7 @@ SENSOR_TYPES_EXTENDED: Final = SENSOR_TYPES_STANDARD + [
 SENSOR_TYPES: Final = {
     "standard": SENSOR_TYPES_STANDARD,
     "extended": SENSOR_TYPES_EXTENDED,
+    "act_standard": SENSOR_TYPES_STANDARD,
 }
 
 TYPES: Final = {
@@ -107,11 +125,14 @@ COORDINATOR_TYPES = {"standard": "", "extended": ""}
 URL_DATA: Final = {
     "standard": "http://www.rfs.nsw.gov.au/feeds/fdrToban.xml",
     "extended": "https://www.rfs.nsw.gov.au/_designs/xml/fire-danger-ratings/fire-danger-ratings-v2",
+    "act_standard": "https://esa.act.gov.au/feeds/firedangerrating.xml",
 }
 
 URL_SERVICE: Final = "http://www.rfs.nsw.gov.au/"
+ACT_URL_SERVICE: Final = "https://esa.act.gov.au/"
 
-VALID_DATA_FEEDS: Final = ["standard", "extended"]
+
+VALID_DATA_FEEDS: Final = ["standard", "extended", "act_standard"]
 
 VALID_DISTRICT_NAMES: Final = [
     "Far North Coast",

--- a/custom_components/nsw_rural_fire_service_fire_danger/const.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/const.py
@@ -36,11 +36,15 @@ XML_SENSOR_ATTRIBUTES: Final = {
     "Councils": ["councils", lambda x, y: [z.strip() for z in x.split(";")]],
     "DangerLevelToday": [
         "danger_level_today",
-        lambda x, y: x.lower().capitalize() if x != "NONE" or not y else "No Rating",
+        lambda x, y: " ".join([w.lower().capitalize() for w in x.split(" ")])
+        if x != "NONE" or not y
+        else "No Rating",
     ],
     "DangerLevelTomorrow": [
         "danger_level_tomorrow",
-        lambda x, y: x.lower().capitalize() if x != "NONE" or not y else "No Rating",
+        lambda x, y: " ".join([w.lower().capitalize() for w in x.split(" ")])
+        if x != "NONE" or not y
+        else "No Rating",
     ],
     "FireBanToday": ["fire_ban_today", lambda x, y: x == "Yes"],
     "FireBanTomorrow": ["fire_ban_tomorrow", lambda x, y: x == "Yes"],

--- a/custom_components/nsw_rural_fire_service_fire_danger/const.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/const.py
@@ -9,7 +9,7 @@ CONF_DISTRICT_NAME: Final = "district_name"
 CONF_DATA_FEED: Final = "data_feed"
 
 DEFAULT_ATTRIBUTION: Final = "NSW Rural Fire Service"
-DEFAULT_ACT_ATTRIBUTION = "ACT Emergency Services Agency"
+DEFAULT_ATTRIBUTION_ACT = "ACT Emergency Services Agency"
 
 DEFAULT_DATA_FEED: Final = "standard"
 
@@ -133,10 +133,11 @@ URL_DATA: Final = {
 }
 
 URL_SERVICE: Final = "http://www.rfs.nsw.gov.au/"
-ACT_URL_SERVICE: Final = "https://esa.act.gov.au/"
+URL_SERVICE_ACT: Final = "https://esa.act.gov.au/"
 
 
 VALID_DATA_FEEDS: Final = ["standard", "extended", "act_standard"]
+ACT_DATA_FEEDS: Final = ["act_standard"]
 
 VALID_DISTRICT_NAMES: Final = [
     "Far North Coast",
@@ -161,3 +162,6 @@ VALID_DISTRICT_NAMES: Final = [
     "South Western",
     "Far Western",
 ]
+
+ACT_IDENTIFIER_SUFFIX: Final = "ESA"
+ACT_DISTRICT_SUFFIX: Final = "(ESA)"

--- a/custom_components/nsw_rural_fire_service_fire_danger/coordinator.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from pyexpat import ExpatError
 
 from .const import (
+    ACT_DISTRICT_SUFFIX,
     CONF_CONVERT_NO_RATING,
     CONF_DISTRICT_NAME,
     DEFAULT_CONVERT_NO_RATING,
@@ -226,6 +227,11 @@ class ActEsaFireDangerStandardFeedCoordinator(NswRfsFireDangerStandardFeedCoordi
             except ExpatError as ex:
                 _LOGGER.warning("Unable to parse feed data: %s", ex)
         return attributes
+
+    @property
+    def district_name(self) -> str:
+        """Return the district name of the coordinator."""
+        return f"{self._district_name} {ACT_DISTRICT_SUFFIX}"
 
 
 class NswRfsFireDangerExtendedFeedCoordinator(NswRfsFireDangerFeedCoordinator):

--- a/custom_components/nsw_rural_fire_service_fire_danger/entity.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/entity.py
@@ -13,13 +13,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import ActEsaFireDangerStandardFeedCoordinator, NswRfsFireDangerFeedCoordinator
 from .const import (
-    DEFAULT_ACT_ATTRIBUTION,
     DEFAULT_ATTRIBUTION,
+    DEFAULT_ATTRIBUTION_ACT,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_NAME_PREFIX,
     DOMAIN,
     TYPES,
     URL_SERVICE,
+    URL_SERVICE_ACT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +40,14 @@ class NswFireServiceFireDangerEntity(CoordinatorEntity[dict[str, Any]]):
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
+
+        if isinstance(coordinator, ActEsaFireDangerStandardFeedCoordinator):
+            self._attr_attribution = DEFAULT_ATTRIBUTION_ACT
+            config_url = URL_SERVICE_ACT
+        else:
+            self._attr_attribution = DEFAULT_ATTRIBUTION
+            config_url = URL_SERVICE
+
         self._sensor_type = sensor_type
         self._attr_name = TYPES[self._sensor_type]
         self._attr_unique_id = f"{config_entry_unique_id}_{self._sensor_type}"
@@ -49,13 +58,8 @@ class NswFireServiceFireDangerEntity(CoordinatorEntity[dict[str, Any]]):
             identifiers={(DOMAIN, self.coordinator.config_entry.entry_id)},
             name=f"{DEFAULT_NAME_PREFIX} {coordinator.district_name}",
             entry_type=DeviceEntryType.SERVICE,
-            configuration_url=URL_SERVICE,
+            configuration_url=config_url,
         )
-
-        if isinstance(coordinator, ActEsaFireDangerStandardFeedCoordinator):
-            self._attr_attribution = DEFAULT_ACT_ATTRIBUTION
-        else:
-            self._attr_attribution = DEFAULT_ATTRIBUTION
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/custom_components/nsw_rural_fire_service_fire_danger/entity.py
+++ b/custom_components/nsw_rural_fire_service_fire_danger/entity.py
@@ -11,8 +11,9 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import NswRfsFireDangerFeedCoordinator
+from . import ActEsaFireDangerStandardFeedCoordinator, NswRfsFireDangerFeedCoordinator
 from .const import (
+    DEFAULT_ACT_ATTRIBUTION,
     DEFAULT_ATTRIBUTION,
     DEFAULT_FORCE_UPDATE,
     DEFAULT_NAME_PREFIX,
@@ -27,7 +28,6 @@ _LOGGER = logging.getLogger(__name__)
 class NswFireServiceFireDangerEntity(CoordinatorEntity[dict[str, Any]]):
     """Implementation of a generic entity."""
 
-    _attr_attribution = DEFAULT_ATTRIBUTION
     _attr_force_update = DEFAULT_FORCE_UPDATE
     _attr_has_entity_name = True
 
@@ -51,6 +51,11 @@ class NswFireServiceFireDangerEntity(CoordinatorEntity[dict[str, Any]]):
             entry_type=DeviceEntryType.SERVICE,
             configuration_url=URL_SERVICE,
         )
+
+        if isinstance(coordinator, ActEsaFireDangerStandardFeedCoordinator):
+            self._attr_attribution = DEFAULT_ACT_ATTRIBUTION
+        else:
+            self._attr_attribution = DEFAULT_ATTRIBUTION
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/tests/nsw_rural_fire_service_fire_danger/conftest.py
+++ b/tests/nsw_rural_fire_service_fire_danger/conftest.py
@@ -38,3 +38,19 @@ def config_entry():
         title="Greater Sydney Region",
         unique_id="Greater Sydney Region",
     )
+
+
+@pytest.fixture
+def act_config_entry():
+    """Create a mock ACT config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DISTRICT_NAME: "ACT",
+            CONF_DATA_FEED: "standard",
+            CONF_CONVERT_NO_RATING: True,
+            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL.total_seconds(),
+        },
+        title="ACT",
+        unique_id="ACT",
+    )

--- a/tests/nsw_rural_fire_service_fire_danger/fixtures/feed-act-1.xml
+++ b/tests/nsw_rural_fire_service_fire_danger/fixtures/feed-act-1.xml
@@ -1,0 +1,19 @@
+<rss version="2.0">
+  <channel>
+  <title>ACT Fire Danger Rating Meter</title>
+  <link>http://esa.act.gov.au</link>
+  <description>ACT Fire Danger Rating Meter</description>
+  <lastBuildDate>Sun, 13 Aug 2023 10:24:05 +1000</lastBuildDate>
+  <pubDate>Sun, 13 Aug 2023 10:24:05 +1000</pubDate>
+  <FireDangerMap>
+    <District>
+      <Name>ACT</Name>
+      <RegionNumber>8</RegionNumber>
+      <DangerLevelToday>No Rating</DangerLevelToday>
+      <DangerLevelTomorrow>No Rating</DangerLevelTomorrow>
+      <FireBanToday>No</FireBanToday>
+      <FireBanTomorrow>No</FireBanTomorrow>
+    </District>
+  </FireDangerMap>
+  </channel>
+</rss>

--- a/tests/nsw_rural_fire_service_fire_danger/test_feed_act_standard.py
+++ b/tests/nsw_rural_fire_service_fire_danger/test_feed_act_standard.py
@@ -25,7 +25,7 @@ from custom_components.nsw_rural_fire_service_fire_danger import (
     DOMAIN,
 )
 
-CONFIG_STANDARD_ACT = {
+CONFIG_ACT_STANDARD_ACT = {
     DOMAIN: {
         CONF_DISTRICT_NAME: "ACT",
         CONF_DATA_FEED: "act_standard",
@@ -48,7 +48,7 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
     assert await async_setup_component(
         hass,
         DOMAIN,
-        CONFIG_STANDARD_ACT,
+        CONFIG_ACT_STANDARD_ACT,
     )
     await hass.async_block_till_done()
 
@@ -60,18 +60,18 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
 
     assert len(hass.states.async_all("binary_sensor")) == 2
 
-    state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_today")
+    state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_today")
     assert state.state == "off"
-    assert state.name == "Fire danger ACT Fire ban today"
+    assert state.name == "Fire danger ACT (ESA) Fire ban today"
     assert state.attributes == {
-        "district": "ACT",
+        "district": "ACT (ESA)",
         "region_number": 8,
         "danger_level_today": "No Rating",
         "danger_level_tomorrow": "No Rating",
         "fire_ban_tomorrow": False,
         ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
         ATTR_DEVICE_CLASS: "safety",
-        "friendly_name": "Fire danger ACT Fire ban today",
+        "friendly_name": "Fire danger ACT (ESA) Fire ban today",
         "last_build_date": datetime(
             2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
         ),
@@ -80,18 +80,18 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
         ),
     }
 
-    state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_tomorrow")
+    state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_tomorrow")
     assert state.state == "off"
-    assert state.name == "Fire danger ACT Fire ban tomorrow"
+    assert state.name == "Fire danger ACT (ESA) Fire ban tomorrow"
     assert state.attributes == {
-        "district": "ACT",
+        "district": "ACT (ESA)",
         "region_number": 8,
         "danger_level_today": "No Rating",
         "danger_level_tomorrow": "No Rating",
         "fire_ban_today": False,
         ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
         ATTR_DEVICE_CLASS: "safety",
-        "friendly_name": "Fire danger ACT Fire ban tomorrow",
+        "friendly_name": "Fire danger ACT (ESA) Fire ban tomorrow",
         "last_build_date": datetime(
             2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
         ),
@@ -102,18 +102,18 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
 
     assert len(hass.states.async_all("sensor")) == 2
 
-    state = hass.states.get("sensor.fire_danger_act_danger_level_today")
+    state = hass.states.get("sensor.fire_danger_act_esa_danger_level_today")
     assert state.state == "No Rating"
-    assert state.name == "Fire danger ACT Danger level today"
+    assert state.name == "Fire danger ACT (ESA) Danger level today"
     assert state.attributes == {
-        "district": "ACT",
+        "district": "ACT (ESA)",
         "region_number": 8,
         "danger_level_tomorrow": "No Rating",
         "fire_ban_today": False,
         "fire_ban_tomorrow": False,
         ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
         ATTR_ICON: "mdi:speedometer-medium",
-        "friendly_name": "Fire danger ACT Danger level today",
+        "friendly_name": "Fire danger ACT (ESA) Danger level today",
         "last_build_date": datetime(
             2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
         ),
@@ -122,18 +122,18 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
         ),
     }
 
-    state = hass.states.get("sensor.fire_danger_act_danger_level_tomorrow")
+    state = hass.states.get("sensor.fire_danger_act_esa_danger_level_tomorrow")
     assert state.state == "No Rating"
-    assert state.name == "Fire danger ACT Danger level tomorrow"
+    assert state.name == "Fire danger ACT (ESA) Danger level tomorrow"
     assert state.attributes == {
-        "district": "ACT",
+        "district": "ACT (ESA)",
         "region_number": 8,
         "danger_level_today": "No Rating",
         "fire_ban_today": False,
         "fire_ban_tomorrow": False,
         ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
         ATTR_ICON: "mdi:speedometer-medium",
-        "friendly_name": "Fire danger ACT Danger level tomorrow",
+        "friendly_name": "Fire danger ACT (ESA) Danger level tomorrow",
         "last_build_date": datetime(
             2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
         ),
@@ -156,7 +156,7 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
 #     assert await async_setup_component(
 #         hass,
 #         DOMAIN,
-#         CONFIG_STANDARD_ACT,
+#         CONFIG_ACT_STANDARD_ACT,
 #     )
 #     await hass.async_block_till_done()
 
@@ -166,13 +166,13 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
 #     )
 #     await hass.async_block_till_done()
 
-#     state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_today")
+#     state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_today")
 #     assert state.state == "off"
-#     state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_tomorrow")
+#     state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_tomorrow")
 #     assert state.state == "unknown"
-#     state = hass.states.get("sensor.fire_danger_act_danger_level_today")
+#     state = hass.states.get("sensor.fire_danger_act_esa_danger_level_today")
 #     assert state.state == "No Rating"
-#     state = hass.states.get("sensor.fire_danger_act_danger_level_tomorrow")
+#     state = hass.states.get("sensor.fire_danger_act_esa_danger_level_tomorrow")
 #     assert state.state == "unknown"
 
 
@@ -187,7 +187,7 @@ async def test_feed_standard_invalid(hass: HomeAssistant, config_entry):
     assert await async_setup_component(
         hass,
         DOMAIN,
-        CONFIG_STANDARD_ACT,
+        CONFIG_ACT_STANDARD_ACT,
     )
     await hass.async_block_till_done()
 
@@ -197,5 +197,5 @@ async def test_feed_standard_invalid(hass: HomeAssistant, config_entry):
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_today")
+    state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_today")
     assert state.state == "unknown"

--- a/tests/nsw_rural_fire_service_fire_danger/test_feed_act_standard.py
+++ b/tests/nsw_rural_fire_service_fire_danger/test_feed_act_standard.py
@@ -143,39 +143,6 @@ async def test_feed_standard_act(hass: HomeAssistant, config_entry):
     }
 
 
-# Commented out until I can work out if this is something we do
-
-# @pytest.mark.asyncio
-# @respx.mock
-# async def test_feed_standard_missing_data(hass: HomeAssistant, config_entry):
-#     """Test standard feed setup and entities."""
-#     await async_setup_component(hass, "homeassistant", {})
-#     respx.get("https://esa.act.gov.au/feeds/firedangerrating.xml").respond(
-#         status_code=HTTPStatus.OK, text=load_fixture("feed-1.xml")
-#     )
-#     assert await async_setup_component(
-#         hass,
-#         DOMAIN,
-#         CONFIG_ACT_STANDARD_ACT,
-#     )
-#     await hass.async_block_till_done()
-
-#     # Refresh the coordinator
-#     async_fire_time_changed(
-#         hass, utcnow() + timedelta(seconds=DEFAULT_SCAN_INTERVAL.total_seconds() + 1)
-#     )
-#     await hass.async_block_till_done()
-
-#     state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_today")
-#     assert state.state == "off"
-#     state = hass.states.get("binary_sensor.fire_danger_act_esa_fire_ban_tomorrow")
-#     assert state.state == "unknown"
-#     state = hass.states.get("sensor.fire_danger_act_esa_danger_level_today")
-#     assert state.state == "No Rating"
-#     state = hass.states.get("sensor.fire_danger_act_esa_danger_level_tomorrow")
-#     assert state.state == "unknown"
-
-
 @pytest.mark.asyncio
 @respx.mock
 async def test_feed_standard_invalid(hass: HomeAssistant, config_entry):

--- a/tests/nsw_rural_fire_service_fire_danger/test_feed_act_standard.py
+++ b/tests/nsw_rural_fire_service_fire_danger/test_feed_act_standard.py
@@ -1,0 +1,201 @@
+"""Define tests for the ACT Emergency Services Agency - Fire Danger standard feed."""
+import logging
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+import pytest
+import respx
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from homeassistant.util import utcnow
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+from tests.nsw_rural_fire_service_fire_danger.utils import load_fixture
+
+from custom_components.nsw_rural_fire_service_fire_danger import (
+    CONF_CONVERT_NO_RATING,
+    CONF_DATA_FEED,
+    CONF_DISTRICT_NAME,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+
+CONFIG_STANDARD_ACT = {
+    DOMAIN: {
+        CONF_DISTRICT_NAME: "ACT",
+        CONF_DATA_FEED: "act_standard",
+        CONF_CONVERT_NO_RATING: True,
+        CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL.total_seconds(),
+    }
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_feed_standard_act(hass: HomeAssistant, config_entry):
+    """Test act_standard feed setup and entities."""
+    await async_setup_component(hass, "homeassistant", {})
+    respx.get("https://esa.act.gov.au/feeds/firedangerrating.xml").respond(
+        status_code=HTTPStatus.OK, text=load_fixture("feed-act-1.xml")
+    )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        CONFIG_STANDARD_ACT,
+    )
+    await hass.async_block_till_done()
+
+    # Refresh the coordinator
+    async_fire_time_changed(
+        hass, utcnow() + timedelta(seconds=DEFAULT_SCAN_INTERVAL.total_seconds() + 1)
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all("binary_sensor")) == 2
+
+    state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_today")
+    assert state.state == "off"
+    assert state.name == "Fire danger ACT Fire ban today"
+    assert state.attributes == {
+        "district": "ACT",
+        "region_number": 8,
+        "danger_level_today": "No Rating",
+        "danger_level_tomorrow": "No Rating",
+        "fire_ban_tomorrow": False,
+        ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
+        ATTR_DEVICE_CLASS: "safety",
+        "friendly_name": "Fire danger ACT Fire ban today",
+        "last_build_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+        "publish_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+    }
+
+    state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_tomorrow")
+    assert state.state == "off"
+    assert state.name == "Fire danger ACT Fire ban tomorrow"
+    assert state.attributes == {
+        "district": "ACT",
+        "region_number": 8,
+        "danger_level_today": "No Rating",
+        "danger_level_tomorrow": "No Rating",
+        "fire_ban_today": False,
+        ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
+        ATTR_DEVICE_CLASS: "safety",
+        "friendly_name": "Fire danger ACT Fire ban tomorrow",
+        "last_build_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+        "publish_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+    }
+
+    assert len(hass.states.async_all("sensor")) == 2
+
+    state = hass.states.get("sensor.fire_danger_act_danger_level_today")
+    assert state.state == "No Rating"
+    assert state.name == "Fire danger ACT Danger level today"
+    assert state.attributes == {
+        "district": "ACT",
+        "region_number": 8,
+        "danger_level_tomorrow": "No Rating",
+        "fire_ban_today": False,
+        "fire_ban_tomorrow": False,
+        ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
+        ATTR_ICON: "mdi:speedometer-medium",
+        "friendly_name": "Fire danger ACT Danger level today",
+        "last_build_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+        "publish_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+    }
+
+    state = hass.states.get("sensor.fire_danger_act_danger_level_tomorrow")
+    assert state.state == "No Rating"
+    assert state.name == "Fire danger ACT Danger level tomorrow"
+    assert state.attributes == {
+        "district": "ACT",
+        "region_number": 8,
+        "danger_level_today": "No Rating",
+        "fire_ban_today": False,
+        "fire_ban_tomorrow": False,
+        ATTR_ATTRIBUTION: "ACT Emergency Services Agency",
+        ATTR_ICON: "mdi:speedometer-medium",
+        "friendly_name": "Fire danger ACT Danger level tomorrow",
+        "last_build_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+        "publish_date": datetime(
+            2023, 8, 13, 10, 24, 5, tzinfo=timezone(timedelta(seconds=36000))
+        ),
+    }
+
+
+# Commented out until I can work out if this is something we do
+
+# @pytest.mark.asyncio
+# @respx.mock
+# async def test_feed_standard_missing_data(hass: HomeAssistant, config_entry):
+#     """Test standard feed setup and entities."""
+#     await async_setup_component(hass, "homeassistant", {})
+#     respx.get("https://esa.act.gov.au/feeds/firedangerrating.xml").respond(
+#         status_code=HTTPStatus.OK, text=load_fixture("feed-1.xml")
+#     )
+#     assert await async_setup_component(
+#         hass,
+#         DOMAIN,
+#         CONFIG_STANDARD_ACT,
+#     )
+#     await hass.async_block_till_done()
+
+#     # Refresh the coordinator
+#     async_fire_time_changed(
+#         hass, utcnow() + timedelta(seconds=DEFAULT_SCAN_INTERVAL.total_seconds() + 1)
+#     )
+#     await hass.async_block_till_done()
+
+#     state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_today")
+#     assert state.state == "off"
+#     state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_tomorrow")
+#     assert state.state == "unknown"
+#     state = hass.states.get("sensor.fire_danger_act_danger_level_today")
+#     assert state.state == "No Rating"
+#     state = hass.states.get("sensor.fire_danger_act_danger_level_tomorrow")
+#     assert state.state == "unknown"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_feed_standard_invalid(hass: HomeAssistant, config_entry):
+    """Test standard feed setup and entities."""
+    await async_setup_component(hass, "homeassistant", {})
+    respx.get("https://esa.act.gov.au/feeds/firedangerrating.xml").respond(
+        status_code=HTTPStatus.OK, text="NOT XML"
+    )
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        CONFIG_STANDARD_ACT,
+    )
+    await hass.async_block_till_done()
+
+    # Refresh the coordinator
+    async_fire_time_changed(
+        hass, utcnow() + timedelta(seconds=DEFAULT_SCAN_INTERVAL.total_seconds() + 1)
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.fire_danger_act_fire_ban_today")
+    assert state.state == "unknown"


### PR DESCRIPTION
Hello from the nations capital!

I've been running a private fork of your custom component with support for the ACT's Emergency Services Agency (ESA) data feed, which is almost identical in format to the RFS data (but only contains the ACT) for a while but after my fork broke, I decided to properly implement my changes and hopefully contribute back upstream. 

My understanding is the BOM produces the fire danger levels for all the jurisdictions and there is some threshold for when a total fire ban (TOBAN) is declared. Jurisdictions are then free to overrule where they see fit. 

The (NSW) RFS feed contains what the danger levels are and if a TOBAN is in place and most of the time, it does match what our ESA states. However, on occasion (or quite frequently during the 2019-20 season) the ESA will come out and declare a TOBAN. This has never been reflected on the RFS's feed.

I've got almost two versions of this pull request, this one I've submitted and one where I've refactored things to be less indentception 🙂  [which you can see here](https://github.com/exxamalte/home-assistant-custom-components-nsw-rural-fire-service-fire-danger/compare/exxamalte:home-assistant-custom-components-nsw-rural-fire-service-fire-danger:main...harrisony:home-assistant-custom-components-nsw-rural-fire-service-fire-danger:code_cleanup)

Happy to submit the code_cleanup branch instead and/or squash these commits